### PR TITLE
Add Quarkus GCP template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,5 @@
-# Compiled class file
-*.class
-
-# Log file
+/build/
+/target/
+.gradle/
 *.log
-
-# BlueJ files
-*.ctxt
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
-# Package Files #
-*.jar
-*.war
-*.nar
-*.ear
-*.zip
-*.tar.gz
-*.rar
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
-replay_pid*
+*.class

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
-# codex-test
-codex-test
+# Quarkus GCP Template
+
+This template provides a starting point for building Java applications with [Quarkus](https://quarkus.io/), [Gradle](https://gradle.org/), and [GraalVM](https://www.graalvm.org/) using [jOOQ](https://www.jooq.org/) with a PostgreSQL database. The project is ready to be containerized and deployed to Google Cloud Platform (GCP), for example to Cloud Run.
+
+## Features
+
+- **Quarkus** framework with RESTEasy Reactive for building REST APIs
+- **Gradle** build tool
+- **GraalVM** native image support
+- **jOOQ** for type-safe database access
+- **PostgreSQL** as the example database
+- Sample REST endpoint `GET /hello`
+
+## Running locally
+
+```bash
+gradle quarkusDev
+```
+
+## Building a native executable
+
+```bash
+gradle build -Dquarkus.package.type=native
+```
+
+The resulting executable can be deployed to GCP (e.g. Cloud Run). Consult the [Quarkus GCP guide](https://quarkus.io/guides/deploying-to-google-cloud) for deployment steps.

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("io.quarkus:quarkus-bom:3.2.7.Final")
+    implementation 'io.quarkus:quarkus-resteasy-reactive'
+    implementation 'io.quarkus:quarkus-jdbc-postgresql'
+    implementation 'io.quarkus:quarkus-hibernate-orm'
+    implementation 'io.quarkus:quarkus-jooq'
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+compileJava.options.encoding = 'UTF-8'
+compileTestJava.options.encoding = 'UTF-8'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'quarkus-template'

--- a/src/main/java/org/acme/GreetingResource.java
+++ b/src/main/java/org/acme/GreetingResource.java
@@ -1,0 +1,16 @@
+package org.acme;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class GreetingResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "Hello, Quarkus";
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,8 @@
+quarkus.datasource.db-kind=postgresql
+quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/mydb
+quarkus.datasource.username=postgres
+quarkus.datasource.password=postgres
+
+quarkus.hibernate-orm.database.generation=drop-and-create
+
+quarkus.jooq.sql-dialect=POSTGRES


### PR DESCRIPTION
## Summary
- add Quarkus template project using Gradle
- include jOOQ and Postgres setup
- provide example REST endpoint
- update README with usage instructions

## Testing
- `gradle -version`

------
https://chatgpt.com/codex/tasks/task_e_68429dcf81f8832cacaffd2abf4da195