### PR TITLE
Add Cirrus CI config

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,8 @@
+# Cirrus CI configuration
+
+build_task:
+  container:
+    image: gradle:jdk17
+  script:
+    - gradle --version
+    - gradle build


### PR DESCRIPTION
## Summary
- set up Cirrus CI with a Gradle build

## Testing
- `gradle build` *(fails: Plugin [id: 'io.quarkus'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a296820c832c90ef82b8db924bdf